### PR TITLE
Add option to ignore the process return value in the sw command call

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ magephp:
                 # Executes all SQL migrations on server(s). Both parameters are optional.
                 - shopware/migrate: { table_suffix: 'bestit', migration_dir: 'sql' }
 
+                # Executes remote the shopware commands
+                
+                # If ignoreReturnValue is true all return values of the command will be ignored. 
+                # The usage of this option should be considered carefully because with this options no differentiation 
+                # between an successful command call and an error command call is possible.
+                # This option is necessary because specific shopware commands like plugin install will indicate an 
+                # if the plugin is already installed
+                
+                # Installs an activate an plugin
+                - shopware/command: { cmd: 'sw:plugin:install --activate Cron', ignoreReturnValue: true }
+
                 # Warms up the shopware theme cache on server(s).
                 - shopware/command: { cmd: 'sw:theme:cache:generate' }
 ```

--- a/src/Shopware/CommandTask.php
+++ b/src/Shopware/CommandTask.php
@@ -57,7 +57,12 @@ class CommandTask extends AbstractTask implements ExecuteOnRollbackInterface
         );
         $process = $this->runtime->runRemoteCommand($cmd, true, $this->options['timeout']);
 
-        return $process->isSuccessful();
+        $returnValue = $process->isSuccessful();
+        if ($this->options['ignoreReturnValue']) {
+            $returnValue = true;
+        }
+
+        return $returnValue;
     }
 
     /**
@@ -82,6 +87,10 @@ class CommandTask extends AbstractTask implements ExecuteOnRollbackInterface
     {
         return [
             'flags' => '',
+            // Ignores the command return value and always returns true
+            // The usage of this option should be considered carefully because with this options all values will
+            // be ignored. Exceptions and other errors wont be detected.
+            'ignoreReturnValue' => false,
             'execOnRollback' => false,
             'timeout' => 120
         ];


### PR DESCRIPTION
Add on additional option for the shopware command task to ignore the process return value. This value can  indicate an error even if the shopware commands executes sucessfully. 

Example:. sw:plugin:install will return an error return code if the plugin is already installed. 