### PR TITLE
Prepares the the tar file of a subfolder without the subfolder itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ magephp:
     php_executable: /usr/bin/php # Leave this empty if you want to use the globally installed php executable.
     custom_tasks:
         - BestIt\Mage\Tasks\Deploy\DeployTask
+        - BestIt\Mage\Tasks\Deploy\Tar\PrepareSubfolderTask     # replaces the original deploy/tar/prepare task
         - BestIt\Mage\Tasks\Env\CreateEnvFileTask        
         - BestIt\Mage\Tasks\Env\SetEnvParametersTask
         - BestIt\Mage\Tasks\Env\RecursiveSetEnvParametersTask

--- a/src/Deploy/Tar/PrepareSubfolderTask.php
+++ b/src/Deploy/Tar/PrepareSubfolderTask.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace BestIt\Mage\Tasks\Deploy\Tar;
+
+use Mage\Task\Exception\ErrorException;
+use Symfony\Component\Process\Process;
+use Mage\Task\BuiltIn\Deploy\Tar\PrepareTask;
+
+/**
+ * Tar Task - Create temporal Tar of files in a specific subfolder
+ *
+ * Replaces the original PrepareTask
+ *
+ * @class PrepareSubfolderTask
+ *
+ * @package BestIt\Mage\Tasks\Deploy\Tar
+ */
+class PrepareSubfolderTask extends PrepareTask
+{
+    public function getName()
+    {
+        return 'deploy/tar/prepare';
+    }
+
+    public function getDescription()
+    {
+        return '[Deploy] Preparing Tar file for subfolder';
+    }
+
+    public function execute()
+    {
+        if (!$this->runtime->getEnvOption('releases', false)) {
+            throw new ErrorException('This task is only available with releases enabled', 40);
+        }
+
+        $tarLocal = $this->runtime->getTempFile();
+        $this->runtime->setVar('tar_local', $tarLocal);
+
+        $excludes = $this->getExcludes();
+        $tarPath = $this->runtime->getEnvOption('tar_create_path', 'tar');
+        $flags = $this->runtime->getEnvOption('tar_create', 'cfzp');
+        $from = $this->runtime->getEnvOption('from', './');
+
+        // create tar of a subfolder
+        $cmdTar = sprintf('%s %s %s %s -C %s .', $tarPath, $flags, $tarLocal, $excludes, $from);
+
+        /** @var Process $process */
+        $process = $this->runtime->runLocalCommand($cmdTar, 300);
+
+        return $process->isSuccessful();
+    }
+}


### PR DESCRIPTION
For deploying a Shopware 6 project, where Shopware itself and our customizations are tracked inside a subfolder, it might be necessary to deploy the code without the subfolder.
This task overrides the default prepareTask for tar files and omits the subfolder by using the "-C" parameter.

See: https://stackoverflow.com/questions/939982/how-do-i-tar-a-directory-of-files-and-folders-without-including-the-directory-it