### PR TITLE
Add config values for showare 6 deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ magephp:
                         - foo
                         - bar
                 # Prefix                                          
-                - env/set-env-parameters: { file: 'configs/config_prod.php', prefix: 'ENV_' }
+                - env/set-env-parameters: { file: 'configs/config_prod.php', prefix: 'ENV_', replaceEnvVariables: true, placeholderWrapper: '__' }
                 # Iterates over all module sub directories, looking for parameter.xml..dist files and creates parameter.xmls from them.
                 - env/recursive-set-env-parameters: { directory: 'custom/plugins/PluginName/Module', fileName: 'parameter.xml.dist', prefix: 'ENV_', encodeForXml: true, deleteTargets: true }
                 - misc/deny-robots-txt: { folder: 'OPTIONAL_LOCAL_FOLDER' }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ magephp:
                         - foo
                         - bar
                 # Prefix                                          
-                - env/set-env-parameters: { file: 'configs/config_prod.php', prefix: 'ENV_', replaceEnvVariables: true, placeholderWrapper: '__' }
+                - env/set-env-parameters: { file: 'configs/config_prod.php', prefix: 'ENV_', placeholderWrapper: '__' }
                 # Iterates over all module sub directories, looking for parameter.xml..dist files and creates parameter.xmls from them.
                 - env/recursive-set-env-parameters: { directory: 'custom/plugins/PluginName/Module', fileName: 'parameter.xml.dist', prefix: 'ENV_', encodeForXml: true, deleteTargets: true }
                 - misc/deny-robots-txt: { folder: 'OPTIONAL_LOCAL_FOLDER' }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ magephp:
     php_executable: /usr/bin/php # Leave this empty if you want to use the globally installed php executable.
     custom_tasks:
         - BestIt\Mage\Tasks\Deploy\DeployTask
+        - BestIt\Mage\Tasks\Deploy\Tar\PrepareSubfolderTask     # replaces the original deploy/tar/prepare task
         - BestIt\Mage\Tasks\Env\CreateEnvFileTask        
         - BestIt\Mage\Tasks\Env\SetEnvParametersTask
         - BestIt\Mage\Tasks\Env\RecursiveSetEnvParametersTask

--- a/src/Deploy/Tar/PrepareSubfolderTask.php
+++ b/src/Deploy/Tar/PrepareSubfolderTask.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace BestIt\Mage\Tasks\Deploy\Tar;
+
+use Mage\Task\Exception\ErrorException;
+use Symfony\Component\Process\Process;
+use Mage\Task\BuiltIn\Deploy\Tar\PrepareTask;
+
+/**
+ * Tar Task - Create temporal Tar of files in a specific subfolder
+ *
+ * Replaces the original PrepareTask
+ *
+ * @class PrepareSubfolderTask
+ *
+ * @package BestIt\Mage\Tasks\Deploy\Tar
+ */
+class PrepareSubfolderTask extends PrepareTask
+{
+    public function getName()
+    {
+        return 'deploy/tar/prepare';
+    }
+
+    public function getDescription()
+    {
+        return '[Deploy] Preparing Tar file for subfolder';
+    }
+
+    public function execute()
+    {
+        if (!$this->runtime->getEnvOption('releases', false)) {
+            throw new ErrorException('This task is only available with releases enabled', 40);
+        }
+
+        $tarLocal = $this->runtime->getTempFile();
+        $this->runtime->setVar('tar_local', $tarLocal);
+
+        $excludes = $this->getExcludes();
+        $tarPath = $this->runtime->getEnvOption('tar_create_path', 'tar');
+        $flags = $this->runtime->getEnvOption('tar_create', 'cfzp');
+        $from = $this->runtime->getEnvOption('from', './');
+
+        // create tar of a subfolder
+        $cmdTar = sprintf('%s %s %s %s -C %s .', $tarPath, $flags, $tarLocal, $excludes, $from);
+
+        /** @var Process $process */
+        $process = $this->runtime->runLocalCommand($cmdTar, 300);
+
+        return $process->isSuccessful();
+    }
+}

--- a/src/Env/SetEnvParametersTask.php
+++ b/src/Env/SetEnvParametersTask.php
@@ -45,7 +45,6 @@ class SetEnvParametersTask extends AbstractTask
         $pathToTarget = isset($this->options['target']) ? $this->options['target'] : $pathToConfig;
         $prefix = $this->options['prefix'];
         $encodeForXml = $this->options['encodeForXml'];
-        $replace = $this->options['replaceEnvVariables'];
         $wrapper = $this->options['placeholderWrapper'];
 
         if (!is_file($pathToConfig)) {
@@ -54,11 +53,7 @@ class SetEnvParametersTask extends AbstractTask
 
         $configContent = file_get_contents($pathToConfig);
 
-        if ($replace) {
-            $envVars = array_replace_recursive($_ENV, $_SERVER);
-        } else {
-            $envVars = array_merge_recursive($_ENV, $_SERVER);
-        }
+        $envVars = array_replace_recursive($_ENV, $_SERVER);
 
         foreach ($envVars as $key => $value) {
             /*
@@ -95,7 +90,6 @@ class SetEnvParametersTask extends AbstractTask
         return [
             'prefix' => 'ENV_',
             'encodeForXml' => false,
-            'replaceEnvVariables' => false,
             'placeholderWrapper' => '%'
         ];
     }

--- a/src/Env/SetEnvParametersTask.php
+++ b/src/Env/SetEnvParametersTask.php
@@ -45,6 +45,8 @@ class SetEnvParametersTask extends AbstractTask
         $pathToTarget = isset($this->options['target']) ? $this->options['target'] : $pathToConfig;
         $prefix = $this->options['prefix'];
         $encodeForXml = $this->options['encodeForXml'];
+        $replace = $this->options['replaceEnvVariables'];
+        $wrapper = $this->options['placeholderWrapper'];
 
         if (!is_file($pathToConfig)) {
             throw new ErrorException("File not found: {$pathToConfig}");
@@ -52,14 +54,18 @@ class SetEnvParametersTask extends AbstractTask
 
         $configContent = file_get_contents($pathToConfig);
 
-        $envVars = array_merge_recursive($_ENV, $_SERVER);
+        if ($replace) {
+            $envVars = array_replace_recursive($_ENV, $_SERVER);
+        } else {
+            $envVars = array_merge_recursive($_ENV, $_SERVER);
+        }
 
         foreach ($envVars as $key => $value) {
             /*
              * Skip all values that are not a string (because we cannot use str_replace on those values).
              * And also skip any keys which do not start with the given prefix.
              * */
-            if (!is_string($value) || strpos($key, $prefix) !== 0) {
+            if (!is_string($value) || (!empty($prefix) && strpos($key, $prefix) !== 0)) {
                 continue;
             }
 
@@ -73,7 +79,7 @@ class SetEnvParametersTask extends AbstractTask
              */
             $placeholder = str_replace($prefix, '', $key);
 
-            $configContent = str_replace("%{$placeholder}%", $value, $configContent);
+            $configContent = str_replace("{$wrapper}{$placeholder}{$wrapper}", $value, $configContent);
         }
 
         $res = file_put_contents($pathToTarget, $configContent);
@@ -88,7 +94,9 @@ class SetEnvParametersTask extends AbstractTask
     {
         return [
             'prefix' => 'ENV_',
-            'encodeForXml' => false
+            'encodeForXml' => false,
+            'replaceEnvVariables' => false,
+            'placeholderWrapper' => '%'
         ];
     }
 }


### PR DESCRIPTION
Adds 2 parameters to the SetEnvParametersTask:

- replaceEnvVariables: to use "array_replace_recursive" instead of "array_merge_recursive"
Otherwise variables that exist in both arrays $_ENV and $_SERVER are merged into an array.
e.g.
$_ENV:    DB_USER=app
$_SERVER:    DB_USER=app
=>
DB_USER = [
    app,
    app
]


- placeholderWrapper: makes the wrapper of placeholders configurable.
defaults to "%", but Showpare 6 utilizes "__"
e.g.: `__DB_USER__`

See: https://github.com/shopware/production/blob/6.1/.env.dist